### PR TITLE
datetime.utcnow() deprecation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/sqlite_migrate/__init__.py
+++ b/sqlite_migrate/__init__.py
@@ -77,7 +77,7 @@ class Migrations:
                 {
                     "migration_set": self.name,
                     "name": name,
-                    "applied_at": str(datetime.datetime.utcnow()),
+                    "applied_at": str(datetime.datetime.now(datetime.UTC)),
                 }
             )
 

--- a/sqlite_migrate/__init__.py
+++ b/sqlite_migrate/__init__.py
@@ -77,7 +77,7 @@ class Migrations:
                 {
                     "migration_set": self.name,
                     "name": name,
-                    "applied_at": str(datetime.datetime.now(datetime.UTC)),
+                    "applied_at": str(datetime.datetime.now(datetime.timezone.utc)),
                 }
             )
 


### PR DESCRIPTION
I noticed some warnings popping up during testing a library under python v3.12 that depends on sqlite_migrate and figured I'd send along the small change.

```
tests/test_sqlite_migrate.py: 4 warnings
tests/test_sqlite_utils_migrate_command.py: 9 warnings
  /Users/edsummers/.local/share/virtualenvs/sqlite-migrate-kmlAZzTv/lib/python3.12/site-packages/sqlite_migrate/__init__.py:80: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "applied_at": str(datetime.datetime.utcnow()),
```

Thanks for a useful module, and for the sqlite-utils/datasette ecosystem!