### PR TITLE
Python library usage documentation, dry run mechanism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,5 @@ jobs:
       run: |
         mypy sqlite_migrate tests
         black --check .
-        ruff .
+        ruff check .
         cog --check README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+venv/
+.venv/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -134,7 +134,31 @@ Schema diff:
 ...
 ```
 
-This is useful for verifying migrations before applying them to a production database.
+The `--dry-run` option copies only the database schema (not the data) to a temporary in-memory database. This is fast and uses minimal memory, but migrations that need to read or transform existing data won't work correctly.
+
+### Dry run with data
+
+For migrations that need access to existing data (e.g., data transformations, populating new columns based on existing values), use `--dry-run-with-data`:
+
+```bash
+sqlite-utils migrate creatures.db --dry-run-with-data
+```
+
+This copies the entire database (schema and data) to an in-memory database using SQLite's backup API. It also reports how many rows were affected:
+
+```
+Dry run (with data) - no changes applied
+
+Would apply 1 migration:
+  - populate_species_count
+
+Rows affected: 150
+
+Schema before:
+...
+```
+
+**Warning:** `--dry-run-with-data` loads the entire database into memory. For large databases (e.g., 2GB+), this may cause memory issues. Use `--dry-run` for quick schema previews when your migrations don't need existing data.
 
 ## Verbose mode
 
@@ -271,17 +295,26 @@ for m in migration.pending(db):
 # Apply migrations up to (but not including) a specific one
 migration.apply(db, stop_before="add_created_at")
 
-# Dry run - preview changes without applying them
+# Dry run - preview changes without applying them (schema only, fast)
 result = migration.apply(db, dry_run=True)
 if result:
     print(f"Would apply: {result.applied}")
     print(f"Schema before:\n{result.before_schema}")
     print(f"Schema after:\n{result.after_schema}")
+
+# Dry run with data - for migrations that need existing data
+result = migration.apply(db, dry_run_with_data=True)
+if result:
+    print(f"Would apply: {result.applied}")
+    print(f"Rows affected: {result.rows_affected}")
 ```
 
 The `db` object passed to each migration function is a [sqlite-utils Database instance](https://sqlite-utils.datasette.io/en/stable/python-api.html), providing a full API for creating tables, inserting data, and modifying schemas.
 
-The `dry_run=True` option returns a `DryRunResult` object with:
+Both `dry_run=True` and `dry_run_with_data=True` return a `DryRunResult` object with:
 - `applied`: List of migration names that would be applied
 - `before_schema`: The database schema before migrations
 - `after_schema`: The database schema after migrations would be applied
+- `rows_affected`: Number of rows modified (only set when using `dry_run_with_data=True`)
+
+Use `dry_run=True` for fast previews when migrations only modify schema. Use `dry_run_with_data=True` when migrations need to read or transform existing data (note: this copies the entire database into memory).

--- a/README.md
+++ b/README.md
@@ -92,6 +92,50 @@ Migrations for: creatures
     drop_table
 ```
 
+## Dry run mode
+
+Add `--dry-run` to preview what migrations would be applied and see the resulting schema changes without actually modifying the database:
+
+```bash
+sqlite-utils migrate creatures.db --dry-run
+```
+Example output:
+```
+Dry run - no changes applied
+
+Would apply 2 migrations:
+  - create_table
+  - add_weight
+
+Schema before:
+
+  (empty)
+
+Schema after:
+
+  CREATE TABLE [_sqlite_migrations] (
+     [id] INTEGER PRIMARY KEY,
+     [migration_set] TEXT,
+     [name] TEXT,
+     [applied_at] TEXT
+  );
+  CREATE UNIQUE INDEX [idx__sqlite_migrations_migration_set_name]
+      ON [_sqlite_migrations] ([migration_set], [name]);
+  CREATE TABLE [creatures] (
+     [id] INTEGER PRIMARY KEY,
+     [name] TEXT,
+     [species] TEXT,
+     [weight] FLOAT
+  );
+
+Schema diff:
+
++CREATE TABLE [_sqlite_migrations] (
+...
+```
+
+This is useful for verifying migrations before applying them to a production database.
+
 ## Verbose mode
 
 Add `-v` or `--verbose` for verbose output, which will show the schema before and after the migrations were applied along with a diff:
@@ -226,6 +270,18 @@ for m in migration.pending(db):
 
 # Apply migrations up to (but not including) a specific one
 migration.apply(db, stop_before="add_created_at")
+
+# Dry run - preview changes without applying them
+result = migration.apply(db, dry_run=True)
+if result:
+    print(f"Would apply: {result.applied}")
+    print(f"Schema before:\n{result.before_schema}")
+    print(f"Schema after:\n{result.after_schema}")
 ```
 
 The `db` object passed to each migration function is a [sqlite-utils Database instance](https://sqlite-utils.datasette.io/en/stable/python-api.html), providing a full API for creating tables, inserting data, and modifying schemas.
+
+The `dry_run=True` option returns a `DryRunResult` object with:
+- `applied`: List of migration names that would be applied
+- `before_schema`: The database schema before migrations
+- `after_schema`: The database schema after migrations would be applied

--- a/README.md
+++ b/README.md
@@ -190,3 +190,42 @@ Schema diff:
  );
 ```
 <!-- [[[end]]] -->
+
+## Using as a Python library
+
+You can also use `sqlite-migrate` directly as a Python library, without the CLI:
+
+```python
+from sqlite_migrate import Migrations
+import sqlite_utils
+
+# Create a migration set with a unique name
+migration = Migrations("myapp")
+
+@migration()
+def create_users(db):
+    db["users"].create({"id": int, "name": str, "email": str}, pk="id")
+
+@migration()
+def add_created_at(db):
+    db["users"].add_column("created_at", str)
+
+# Connect to a database
+db = sqlite_utils.Database("myapp.db")
+
+# Apply all pending migrations
+migration.apply(db)
+
+# Check which migrations have been applied
+for m in migration.applied(db):
+    print(f"Applied: {m.name} at {m.applied_at}")
+
+# Check which migrations are still pending
+for m in migration.pending(db):
+    print(f"Pending: {m.name}")
+
+# Apply migrations up to (but not including) a specific one
+migration.apply(db, stop_before="add_created_at")
+```
+
+The `db` object passed to each migration function is a [sqlite-utils Database instance](https://sqlite-utils.datasette.io/en/stable/python-api.html), providing a full API for creating tables, inserting data, and modifying schemas.

--- a/sqlite_migrate/__init__.py
+++ b/sqlite_migrate/__init__.py
@@ -108,14 +108,15 @@ class Migrations:
                     applied=[],
                 )
 
-            # Create a temporary in-memory copy of the database to run migrations
-            # This avoids issues with sqlite-utils auto-committing transactions
+            # Create a temporary in-memory database with just the schema (no data)
+            # This avoids memory issues with large databases
             import sqlite3
 
             temp_conn = sqlite3.connect(":memory:")
 
-            # Copy schema and data from original database
-            db.conn.backup(temp_conn)
+            # Copy only the schema, not the data
+            if before_schema:
+                temp_conn.executescript(before_schema)
 
             # Import Database here to avoid circular import issues
             from sqlite_utils import Database as SqliteDatabase

--- a/sqlite_migrate/__init__.py
+++ b/sqlite_migrate/__init__.py
@@ -1,10 +1,19 @@
 from dataclasses import dataclass
 import datetime
-from typing import cast, Callable, List, Optional
+from typing import cast, Callable, List, Optional, Union
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sqlite_utils.db import Database, Table
+
+
+@dataclass
+class DryRunResult:
+    """Result of a dry-run migration."""
+
+    before_schema: str
+    after_schema: str
+    applied: List[str]
 
 
 class Migrations:
@@ -68,15 +77,73 @@ class Migrations:
             )
         ]
 
-    def apply(self, db: "Database", *, stop_before: Optional[str] = None):
+    def apply(
+        self,
+        db: "Database",
+        *,
+        stop_before: Optional[str] = None,
+        dry_run: bool = False,
+    ) -> Optional[DryRunResult]:
         """
         Apply any pending migrations to the database.
+
+        :param db: The sqlite-utils Database instance
+        :param stop_before: Stop before applying this migration
+        :param dry_run: If True, run migrations in a transaction then rollback,
+            returning a DryRunResult with schema before/after and list of
+            migrations that would be applied
+        :return: DryRunResult if dry_run=True, otherwise None
         """
         self.ensure_migrations_table(db)
-        for migration in self.pending(db):
+        pending = self.pending(db)
+
+        if dry_run:
+            before_schema = db.schema
+            applied_names: List[str] = []
+
+            if not pending:
+                return DryRunResult(
+                    before_schema=before_schema,
+                    after_schema=before_schema,
+                    applied=[],
+                )
+
+            # Create a temporary in-memory copy of the database to run migrations
+            # This avoids issues with sqlite-utils auto-committing transactions
+            import sqlite3
+
+            temp_conn = sqlite3.connect(":memory:")
+
+            # Copy schema and data from original database
+            db.conn.backup(temp_conn)
+
+            # Import Database here to avoid circular import issues
+            from sqlite_utils import Database as SqliteDatabase
+
+            temp_db = SqliteDatabase(temp_conn)
+
+            # Run migrations on the temporary copy
+            for migration in pending:
+                name = migration.name
+                if name == stop_before:
+                    break
+                migration.fn(temp_db)
+                applied_names.append(name)
+
+            after_schema = temp_db.schema
+            temp_conn.close()
+
+            return DryRunResult(
+                before_schema=before_schema,
+                after_schema=after_schema,
+                applied=applied_names,
+            )
+
+        # Normal apply
+        for migration in pending:
             name = migration.name
             if name == stop_before:
-                return
+                return None
             migration.fn(db)
             _table(db, self.migrations_table).insert(
                 {
@@ -85,6 +152,7 @@ class Migrations:
                     "applied_at": str(datetime.datetime.now(datetime.timezone.utc)),
                 }
             )
+        return None
 
     def ensure_migrations_table(self, db: "Database"):
         """

--- a/sqlite_migrate/__init__.py
+++ b/sqlite_migrate/__init__.py
@@ -14,6 +14,7 @@ class DryRunResult:
     before_schema: str
     after_schema: str
     applied: List[str]
+    rows_affected: Optional[int] = None  # Only set when dry_run_with_data=True
 
 
 class Migrations:
@@ -83,21 +84,28 @@ class Migrations:
         *,
         stop_before: Optional[str] = None,
         dry_run: bool = False,
+        dry_run_with_data: bool = False,
     ) -> Optional[DryRunResult]:
         """
         Apply any pending migrations to the database.
 
         :param db: The sqlite-utils Database instance
         :param stop_before: Stop before applying this migration
-        :param dry_run: If True, run migrations in a transaction then rollback,
-            returning a DryRunResult with schema before/after and list of
-            migrations that would be applied
-        :return: DryRunResult if dry_run=True, otherwise None
+        :param dry_run: If True, copies only the schema to an in-memory database,
+            runs migrations there, and returns the result without modifying the
+            original database. Use this for fast previews when migrations don't
+            need existing data.
+        :param dry_run_with_data: If True, copies the entire database (schema and
+            data) to an in-memory database using SQLite's backup API, runs
+            migrations there, and returns the result. Use this when migrations
+            need to read or transform existing data. Warning: may use significant
+            memory for large databases.
+        :return: DryRunResult if dry_run or dry_run_with_data is True, otherwise None
         """
         self.ensure_migrations_table(db)
         pending = self.pending(db)
 
-        if dry_run:
+        if dry_run or dry_run_with_data:
             before_schema = db.schema
             applied_names: List[str] = []
 
@@ -108,20 +116,27 @@ class Migrations:
                     applied=[],
                 )
 
-            # Create a temporary in-memory database with just the schema (no data)
-            # This avoids memory issues with large databases
             import sqlite3
 
             temp_conn = sqlite3.connect(":memory:")
 
-            # Copy only the schema, not the data
-            if before_schema:
-                temp_conn.executescript(before_schema)
+            if dry_run_with_data:
+                # Copy entire database including data using backup API
+                # Warning: may use significant memory for large databases
+                db.conn.backup(temp_conn)
+            else:
+                # Copy only the schema, not the data
+                # This avoids memory issues with large databases
+                if before_schema:
+                    temp_conn.executescript(before_schema)
 
             # Import Database here to avoid circular import issues
             from sqlite_utils import Database as SqliteDatabase
 
             temp_db = SqliteDatabase(temp_conn)
+
+            # Track row changes if using dry_run_with_data
+            rows_before = temp_conn.total_changes if dry_run_with_data else None
 
             # Run migrations on the temporary copy
             for migration in pending:
@@ -132,12 +147,18 @@ class Migrations:
                 applied_names.append(name)
 
             after_schema = temp_db.schema
+            rows_affected = (
+                temp_conn.total_changes - rows_before
+                if rows_before is not None
+                else None
+            )
             temp_conn.close()
 
             return DryRunResult(
                 before_schema=before_schema,
                 after_schema=after_schema,
                 applied=applied_names,
+                rows_affected=rows_affected,
             )
 
         # Normal apply

--- a/sqlite_migrate/__init__.py
+++ b/sqlite_migrate/__init__.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import datetime
-from typing import cast, Callable, List, Optional, Union
+from typing import cast, Callable, List, Optional
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sqlite_migrate/sqlite_utils_plugin.py
+++ b/sqlite_migrate/sqlite_utils_plugin.py
@@ -21,9 +21,14 @@ def register_commands(cli):
     @click.option(
         "--dry-run",
         is_flag=True,
-        help="Show what migrations would be applied without applying them",
+        help="Preview migrations using schema only (fast, low memory)",
     )
-    def migrate(db_path, migrations, stop_before, list_, verbose, dry_run):
+    @click.option(
+        "--dry-run-with-data",
+        is_flag=True,
+        help="Preview migrations with full data copy (for data-dependent migrations)",
+    )
+    def migrate(db_path, migrations, stop_before, list_, verbose, dry_run, dry_run_with_data):
         """
         Apply pending database migrations.
 
@@ -74,8 +79,10 @@ def register_commands(cli):
             display_list(db, migration_sets)
             return
 
-        if dry_run:
-            display_dry_run(db, migration_sets, stop_before=stop_before)
+        if dry_run or dry_run_with_data:
+            display_dry_run(
+                db, migration_sets, stop_before=stop_before, with_data=dry_run_with_data
+            )
             return
 
         prev_schema = db.schema
@@ -127,21 +134,32 @@ def display_list(db, migration_sets):
         print()
 
 
-def display_dry_run(db, migration_sets, stop_before=None):
+def display_dry_run(db, migration_sets, stop_before=None, with_data=False):
     """Display what migrations would be applied without actually applying them."""
     all_applied = []
     combined_before = None
     combined_after = None
+    total_rows_affected = 0
 
     for migration_set in migration_sets:
-        result = migration_set.apply(db, stop_before=stop_before, dry_run=True)
+        if with_data:
+            result = migration_set.apply(
+                db, stop_before=stop_before, dry_run_with_data=True
+            )
+            if result.rows_affected is not None:
+                total_rows_affected += result.rows_affected
+        else:
+            result = migration_set.apply(db, stop_before=stop_before, dry_run=True)
         all_applied.extend(result.applied)
         # Use the first before_schema and last after_schema
         if combined_before is None:
             combined_before = result.before_schema
         combined_after = result.after_schema
 
-    click.echo("Dry run - no changes applied\n")
+    if with_data:
+        click.echo("Dry run (with data) - no changes applied\n")
+    else:
+        click.echo("Dry run - no changes applied\n")
 
     if not all_applied:
         click.echo("No pending migrations")
@@ -155,6 +173,9 @@ def display_dry_run(db, migration_sets, stop_before=None):
     for name in all_applied:
         click.echo("  - {}".format(name))
     click.echo()
+
+    if with_data:
+        click.echo("Rows affected: {}\n".format(total_rows_affected))
 
     click.echo("Schema before:\n")
     click.echo(textwrap.indent(combined_before, "  ") or "  (empty)")

--- a/sqlite_migrate/sqlite_utils_plugin.py
+++ b/sqlite_migrate/sqlite_utils_plugin.py
@@ -18,7 +18,12 @@ def register_commands(cli):
         "list_", "--list", is_flag=True, help="List migrations without running them"
     )
     @click.option("-v", "--verbose", is_flag=True, help="Show verbose output")
-    def migrate(db_path, migrations, stop_before, list_, verbose):
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        help="Show what migrations would be applied without applying them",
+    )
+    def migrate(db_path, migrations, stop_before, list_, verbose, dry_run):
         """
         Apply pending database migrations.
 
@@ -69,6 +74,10 @@ def register_commands(cli):
             display_list(db, migration_sets)
             return
 
+        if dry_run:
+            display_dry_run(db, migration_sets, stop_before=stop_before)
+            return
+
         prev_schema = db.schema
         if verbose:
             click.echo("Migrating {}".format(db_path))
@@ -116,3 +125,49 @@ def display_list(db, migration_sets):
         if not output:
             print("    (none)")
         print()
+
+
+def display_dry_run(db, migration_sets, stop_before=None):
+    """Display what migrations would be applied without actually applying them."""
+    all_applied = []
+    combined_before = None
+    combined_after = None
+
+    for migration_set in migration_sets:
+        result = migration_set.apply(db, stop_before=stop_before, dry_run=True)
+        all_applied.extend(result.applied)
+        # Use the first before_schema and last after_schema
+        if combined_before is None:
+            combined_before = result.before_schema
+        combined_after = result.after_schema
+
+    click.echo("Dry run - no changes applied\n")
+
+    if not all_applied:
+        click.echo("No pending migrations")
+        return
+
+    click.echo("Would apply {} migration{}:".format(
+        len(all_applied), "s" if len(all_applied) != 1 else ""
+    ))
+    for name in all_applied:
+        click.echo("  - {}".format(name))
+    click.echo()
+
+    click.echo("Schema before:\n")
+    click.echo(textwrap.indent(combined_before, "  ") or "  (empty)")
+    click.echo()
+
+    click.echo("Schema after:\n")
+    if combined_after == combined_before:
+        click.echo("  (unchanged)")
+    else:
+        click.echo(textwrap.indent(combined_after, "  "))
+        click.echo("\nSchema diff:\n")
+        diff = list(
+            difflib.unified_diff(
+                combined_before.splitlines(), combined_after.splitlines()
+            )
+        )
+        # Skip the first three lines (filenames and @@ markers)
+        click.echo("\n".join(diff[3:]))

--- a/sqlite_migrate/sqlite_utils_plugin.py
+++ b/sqlite_migrate/sqlite_utils_plugin.py
@@ -147,9 +147,11 @@ def display_dry_run(db, migration_sets, stop_before=None):
         click.echo("No pending migrations")
         return
 
-    click.echo("Would apply {} migration{}:".format(
-        len(all_applied), "s" if len(all_applied) != 1 else ""
-    ))
+    click.echo(
+        "Would apply {} migration{}:".format(
+            len(all_applied), "s" if len(all_applied) != 1 else ""
+        )
+    )
     for name in all_applied:
         click.echo("  - {}".format(name))
     click.echo()

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -113,3 +113,56 @@ def test_upgrades_sqlite_migrations(migrations, create_table, pk):
     assert db["_sqlite_migrations"].pks == [pk] if isinstance(pk, str) else pk
     migrations.apply(db)
     assert db["_sqlite_migrations"].pks == ["id"]
+
+
+def test_dry_run(migrations):
+    db = sqlite_utils.Database(memory=True)
+    assert db.table_names() == []
+
+    # Dry run should return result with schema info but not modify database
+    result = migrations.apply(db, dry_run=True)
+
+    # Database should still be empty (except migrations table from ensure_migrations_table)
+    assert "dogs" not in db.table_names()
+    assert "cats" not in db.table_names()
+
+    # Result should contain schema information
+    assert result is not None
+    assert result.before_schema is not None
+    assert result.after_schema is not None
+    assert "dogs" in result.after_schema
+    assert "cats" in result.after_schema
+    assert result.applied == ["m001", "m002"]
+
+    # Now actually apply and verify it works
+    migrations.apply(db)
+    assert set(db.table_names()) == {"_sqlite_migrations", "dogs", "cats"}
+
+
+def test_dry_run_with_stop_before(migrations):
+    db = sqlite_utils.Database(memory=True)
+
+    # Dry run with stop_before
+    result = migrations.apply(db, dry_run=True, stop_before="m002")
+
+    # Should only show m001 as applied
+    assert result.applied == ["m001"]
+    assert "dogs" in result.after_schema
+    assert "cats" not in result.after_schema
+
+    # Database should still be unchanged
+    assert "dogs" not in db.table_names()
+
+
+def test_dry_run_no_pending(migrations):
+    db = sqlite_utils.Database(memory=True)
+
+    # Apply migrations first
+    migrations.apply(db)
+
+    # Dry run with no pending migrations
+    result = migrations.apply(db, dry_run=True)
+
+    assert result is not None
+    assert result.applied == []
+    assert result.before_schema == result.after_schema

--- a/tests/test_sqlite_migrate.py
+++ b/tests/test_sqlite_migrate.py
@@ -166,3 +166,41 @@ def test_dry_run_no_pending(migrations):
     assert result is not None
     assert result.applied == []
     assert result.before_schema == result.after_schema
+
+
+def test_dry_run_with_data():
+    """Test dry_run_with_data copies data for migrations that need it."""
+    migrations = Migrations("data_test")
+
+    @migrations()
+    def create_table(db):
+        db["items"].create({"id": int, "name": str}, pk="id")
+
+    @migrations()
+    def count_items(db):
+        # This migration needs data to work correctly
+        count = list(db.execute("SELECT COUNT(*) FROM items").fetchone())[0]
+        db["stats"].insert({"item_count": count})
+
+    db = sqlite_utils.Database(memory=True)
+
+    # Create table and insert some data
+    db["items"].create({"id": int, "name": str}, pk="id")
+    db["items"].insert_all([{"id": 1, "name": "one"}, {"id": 2, "name": "two"}])
+
+    # Mark first migration as already applied
+    migrations.ensure_migrations_table(db)
+    db["_sqlite_migrations"].insert(
+        {"migration_set": "data_test", "name": "create_table", "applied_at": "2024-01-01"}
+    )
+
+    # dry_run_with_data should copy the data
+    result = migrations.apply(db, dry_run_with_data=True)
+
+    assert result is not None
+    assert result.applied == ["count_items"]
+    assert "stats" in result.after_schema
+
+    # Original database should be unchanged
+    assert "stats" not in db.table_names()
+    assert list(db["items"].rows) == [{"id": 1, "name": "one"}, {"id": 2, "name": "two"}]

--- a/tests/test_sqlite_utils_migrate_command.py
+++ b/tests/test_sqlite_utils_migrate_command.py
@@ -254,4 +254,7 @@ def test_dry_run_no_pending(two_migrations):
         ["migrate", db_path, str(path / "foo" / "migrations.py"), "--dry-run"],
     )
     assert result.exit_code == 0
-    assert "No pending migrations" in result.output or "no pending" in result.output.lower()
+    assert (
+        "No pending migrations" in result.output
+        or "no pending" in result.output.lower()
+    )

--- a/tests/test_sqlite_utils_migrate_command.py
+++ b/tests/test_sqlite_utils_migrate_command.py
@@ -206,3 +206,52 @@ def foo(db):
         "--stop-before can only be used with a single migrations.py file"
         in result.output
     )
+
+
+def test_dry_run(two_migrations):
+    path, _ = two_migrations
+    db_path = str(path / "test.db")
+    runner = CliRunner()
+
+    # Run with --dry-run flag
+    result = runner.invoke(
+        sqlite_utils.cli.cli,
+        ["migrate", db_path, str(path / "foo" / "migrations.py"), "--dry-run"],
+    )
+    assert result.exit_code == 0
+
+    # Output should indicate it's a dry run
+    assert "Dry run" in result.output or "dry run" in result.output
+
+    # Should show which migrations would be applied
+    assert "foo" in result.output
+    assert "bar" in result.output
+
+    # Should show schema diff
+    assert "Schema" in result.output
+
+    # Database should NOT have the tables (dry run doesn't apply)
+    db = sqlite_utils.Database(db_path)
+    assert not db["foo"].exists()
+    assert not db["bar"].exists()
+
+
+def test_dry_run_no_pending(two_migrations):
+    path, _ = two_migrations
+    db_path = str(path / "test.db")
+    runner = CliRunner()
+
+    # First apply the migrations
+    result = runner.invoke(
+        sqlite_utils.cli.cli,
+        ["migrate", db_path, str(path / "foo" / "migrations.py")],
+    )
+    assert result.exit_code == 0
+
+    # Now run dry-run with no pending migrations
+    result = runner.invoke(
+        sqlite_utils.cli.cli,
+        ["migrate", db_path, str(path / "foo" / "migrations.py"), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "No pending migrations" in result.output or "no pending" in result.output.lower()

--- a/tests/test_sqlite_utils_migrate_command.py
+++ b/tests/test_sqlite_utils_migrate_command.py
@@ -258,3 +258,49 @@ def test_dry_run_no_pending(two_migrations):
         "No pending migrations" in result.output
         or "no pending" in result.output.lower()
     )
+
+
+def test_dry_run_with_data(tmpdir):
+    """Test --dry-run-with-data flag copies data for migrations that need it."""
+    path = pathlib.Path(tmpdir)
+    (path / "foo").mkdir()
+    migrations_py = path / "foo" / "migrations.py"
+    migrations_py.write_text(
+        """
+from sqlite_migrate import Migrations
+
+m = Migrations("data_test")
+
+@m()
+def count_items(db):
+    count = list(db.execute("SELECT COUNT(*) FROM items").fetchone())[0]
+    db["stats"].insert({"item_count": count})
+    """,
+        "utf-8",
+    )
+    db_path = str(path / "test.db")
+
+    # Create database with some data
+    db = sqlite_utils.Database(db_path)
+    db["items"].insert_all([{"id": 1, "name": "one"}, {"id": 2, "name": "two"}])
+
+    runner = CliRunner()
+
+    # Run with --dry-run-with-data flag
+    result = runner.invoke(
+        sqlite_utils.cli.cli,
+        ["migrate", db_path, str(migrations_py), "--dry-run-with-data"],
+    )
+    assert result.exit_code == 0
+
+    # Output should indicate it's a dry run
+    assert "Dry run" in result.output
+
+    # Should show stats table in schema
+    assert "stats" in result.output
+
+    # Database should NOT have the stats table (dry run doesn't apply)
+    db = sqlite_utils.Database(db_path)
+    assert not db["stats"].exists()
+    # Original data should be intact
+    assert db["items"].count == 2


### PR DESCRIPTION
Document how to use sqlite-migrate directly as a Python library,
addressing issue #3. Includes examples for applying migrations,
checking applied/pending status, and using stop_before.